### PR TITLE
Remove dependency on `minimist`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1651,7 +1651,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://nexus3.linkurious.net/repository/npm/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "mitt": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
     "tape": "^5.2.2",
     "xmldom": "^0.6.0"
   },
-  "dependencies": {
-    "minimist": "^1.2.5"
-  },
   "keywords": [
     "gis",
     "wms",


### PR DESCRIPTION
Summary:
 -  `minimist` v1.2.5 has a [prototype pollution vulnerability](https://security.snyk.io/package/npm/minimist/1.2.5).
 -  The dependency is not used.

To-dos:
 - [x] Checked that the dependency is not used anywhere.
 - [x] All tests are green.

Thanks for the awesome library.