### PR TITLE
Fixed WMS constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -194,7 +194,7 @@ export default class WMS {
    * @param {String=} xmlString
    * @constructor
    */
-  constructor(xmlString?: string | undefined, DOMParser: any);
+  constructor(xmlString?: string | undefined, DOMParser?: any);
   /**
    * @type {String}
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wms-capabilities",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wms-capabilities",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "WMS service Capabilities > JSON, based on openlayers ",
   "main": "dist/wms-capabilities.min.js",
   "module": "dist/wms-capabilities.mjs",


### PR DESCRIPTION
TypeScript applications cannot use this library because an optional parameter cannot come before a required parameter. With this change, both parameters are optional so that TypeScript can compile.